### PR TITLE
Revert temporary fix for Atom grammar updating

### DIFF
--- a/lib/css-declaration-sorter.js
+++ b/lib/css-declaration-sorter.js
@@ -13,7 +13,7 @@ const syntaxes = {
 
 module.exports = {
   activate: function () {
-    return atom.commands.add('atom-text-editor', {
+    return atom.commands.add('atom-text-editor[data-grammar~=\'css\']', {
       'css-declaration-sorter:sort': function () {
         var sortOrder = atom.config.get('css-declaration-sorter.sortOrder');
         return sort(sortOrder);

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -14,6 +14,7 @@ describe('CSS Declaration Sorter', function () {
     waitsForPromise(function () {
       return atom.workspace.open().then(function (result) {
         editor = result;
+        jasmine.attachToDOM(editor.element);
         workspaceElement = atom.views.getView(editor);
         spyOn(editor, 'getText').andCallThrough();
       });


### PR DESCRIPTION
Atom now handles updating the grammar asynchronously, this caused the
tests to fail.

See https://github.com/atom/atom/issues/15447 for more context.